### PR TITLE
SUP-4424 Provide BK API Token to the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Buildkite plugin that allows the user to send a prompt to ChatGPT
 
 - **curl**: For API requests
 - **jq**: For JSON processing
-- **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from the [OpenAI Platform account](http://platform.openai.com/login)
+- **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from your [OpenAI Platform account](http://platform.openai.com/login)
 
 ## Quick Start
 1.  Create an OpenAI platform account from [OpenAI account](http://platform.openai.com/login), or log in to an existing one. Generate an OpenAI API Key from the OpenAI dashboard -> View OpenAI Keys menu. 
@@ -27,21 +27,23 @@ A Buildkite plugin that allows the user to send a prompt to ChatGPT
 
 ```
 steps:
-  # Option 1: Using environment variable set at upload time
-  - label: "Generate tests"
-    command: echo "Generate tests"
+  # Option 1: Using environment variable set at upload time 
+  - label: "🔍 Prompt ChatGPT to summarise test results"
+    command: "npm test"
     plugins:
-      - chatgpt-promptere#v1.0.0:
-          api_key: "$$OPENAI_API_KEY"
+      - chatgpt-prompter#v0.0.1:
+          api_key: "$$OPENAI_API_KEY" 
 
   # Option 2: Using Buildkite secrets (recommended)
   # First, create .buildkite/hooks/pre-command with:
-  # export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY)
-  - label: "Run tests"
-    command: echo "Run tests"
+  # export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY) 
+  # export BUILDKITE_API_TOKEN=$(buildkite-agent secret get BUILDKITE_API_TOKEN)   
+  - label: "🔍 Prompt ChatGPT to summarise build"
+    command: echo "Summarise build"
     plugins:
-      - claude-summarize#v1.0.0:
+      - chatgpt-prompter#v0.0.1:
           api_key: "$$OPENAI_API_KEY"
+          buildkite_api_token: "$$BUILDKITE_API_TOKEN" 
 ```
 
 
@@ -65,6 +67,7 @@ The name of the Buildkite secret key that contains your OpenAI API token to use 
 
 The Buildkite API token to use for fetching build information from the Buildkite API to use for build analysis. If not specified, the plugin will look for BUILDKITE_API_TOKEN in the environment.
 
+
 #### `model` (string)
 
 The ChatGPT model. Defaults to `GPT-4o mini`.
@@ -83,8 +86,7 @@ steps:
     command: "npm test"
     plugins:
       - chatgpt-prompter#v0.0.1:
-          api_secret_key_name: "CHATGPT_SECRET_KEY_NAME" 
-          bk_token_secret_key: "ORG_USER_TOKEN_SECRET_KEY_NAME"
+          api_key: "$$OPENAI_API_KEY" 
 ```
 
 ## Provide Aditional Context  
@@ -97,8 +99,8 @@ steps:
     command: "echo template plugin with options"
     plugins:
       - chatgpt-prompter#v0.0.1:
-          api_secret_key_name: "CHATGPT_SECRET_KEY_NAME" 
-          bk_token_secret_key: "ORG_USER_TOKEN_SECRET_KEY_NAME"
+          api_key: "$$OPENAI_API_KEY"
+          buildkite_api_token: "$$BUILDKITE_API_TOKEN"
           model: "GPT-4o"
           custom_prompt: "Focus on build performance and optimization opportunities"
         

--- a/README.md
+++ b/README.md
@@ -8,21 +8,62 @@ A Buildkite plugin that allows the user to send a prompt to ChatGPT
 - **jq**: For JSON processing
 - **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from the [OpenAI Platform account](http://platform.openai.com/login)
 
+## Requirements
+
+- **curl**: For API requests
+- **jq**: For JSON processing
+- **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from the [OpenAI Platform account](http://platform.openai.com/login)
+
+## Quick Start
+1.  Create an OpenAI platform account from [OpenAI account](http://platform.openai.com/login), or log in to an existing one. Generate an OpenAI API Key from the OpenAI dashboard -> View OpenAI Keys menu. 
+2. Add to your Buildkite environment variable as `OPENAI_API_KEY` 
+3. For Buildkite secrets, create a repository pre-command hook (.buildkite/hooks/pre-command)  and set the environment variable: 
+   ```bash
+   #!/bin/bash
+   export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY) 
+   export BUILDKITE_API_TOKEN=$(buildkite-agent secret get BUILDKITE_API_TOKEN)    
+   ```   
+4. Add the plugin to your pipeline using the following examples
+
+```
+steps:
+  # Option 1: Using environment variable set at upload time
+  - label: "Generate tests"
+    command: echo "Generate tests"
+    plugins:
+      - chatgpt-promptere#v1.0.0:
+          api_key: "$$OPENAI_API_KEY"
+
+  # Option 2: Using Buildkite secrets (recommended)
+  # First, create .buildkite/hooks/pre-command with:
+  # export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY)
+  - label: "Run tests"
+    command: echo "Run tests"
+    plugins:
+      - claude-summarize#v1.0.0:
+          api_key: "$$OPENAI_API_KEY"
+```
+
+
 ## Options
 
 These are all the options available to configure this plugin's behaviour.
 
 ### Required
 
-#### `api_secret_key_name` (string)
+#### `api_key` (string)
 
-The name of the Buildkite secret key that contains your OpenAI API token to use for ChatGPT access. 
+The name of the Buildkite secret key that contains your OpenAI API token to use for ChatGPT access. Use an environment variable reference for this.
 
-#### `bk_token_secret_key` (string)
+- **Environment variable**: `"${OPENAI_API_KEY}"` - References an environment variable set at upload time
+- **Buildkite secrets**: Create `.buildkite/hooks/pre-command` with `export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY)`, then use `"$$OPENAI_API_KEY"` (recommended)
 
-The name of the Buildkite secret key that contains the Buildkite API toke to use for Build analysis. 
 
 ### Optional
+
+#### `buildkite_api_token` (string)
+
+The Buildkite API token to use for fetching build information from the Buildkite API to use for build analysis. If not specified, the plugin will look for BUILDKITE_API_TOKEN in the environment.
 
 #### `model` (string)
 

--- a/README.md
+++ b/README.md
@@ -12,59 +12,48 @@ These are all the options available to configure this plugin's behaviour.
 
 The name of the Buildkite secret key that contains your OpenAI API token to use for ChatGPT access. 
 
+#### `bk_token_secret_key` (string)
+
+The name of the Buildkite secret key that contains the Buildkite API toke to use for Build analysis. 
+
 ### Optional
 
 #### `model` (string)
 
 The ChatGPT model. Defaults to `GPT-4o mini`.
 
-#### `user_prompt` (string)
+#### `custom_prompt` (string)
 
-The user prompt to send to ChatGPT. Defaults to "ping" the ChatGPT API.
-
-Example of the default payload sent on a ping: 
-
-```
-{
-  "model": "gpt-3.5-turbo",
-  "messages": [
-    {"role": "user", "content": "ping"}
-  ],
-  "max_tokens": 1,
-  "temperature": 0
-}
-```
-
-#### `system_prompt` (string)
-
-An option to provide a system prompt to ChatGPT together with the user prompt.
+Additional context to prompt ChatGPT for include in its analysis.   
 
 ## Examples
 
-Show how your plugin is to be used
+### Basic Usage - Analyse Current Build
 
 ```yaml
 steps:
-  - label: "🔨 Running plugin"
-    command: "echo template plugin"
+  - label: "🔍 Prompt ChatGPT to summarise build"
+    command: "npm test"
     plugins:
       - chatgpt-prompter#v0.0.1:
           api_secret_key_name: "CHATGPT_SECRET_KEY_NAME" 
+          bk_token_secret_key: "ORG_USER_TOKEN_SECRET_KEY_NAME"
 ```
 
-## And with other options as well
+## Provide Aditional Context  
 
-If you want to change the plugin behaviour:
+If you want to provide additional context or instructions to the default build summary, provide a `custom_prompt` parameter to the plugin. 
 
 ```yaml
 steps:
-  - label: "🔨 Running plugin"
+  - label: "🔍 Prompt ChatGPT to focus on build performance"
     command: "echo template plugin with options"
     plugins:
       - chatgpt-prompter#v0.0.1:
           api_secret_key_name: "CHATGPT_SECRET_KEY_NAME" 
+          bk_token_secret_key: "ORG_USER_TOKEN_SECRET_KEY_NAME"
           model: "GPT-4o"
-          user_prompt: "Ping"
+          custom_prompt: "Focus on build performance and optimization opportunities"
         
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,40 +4,41 @@ A Buildkite plugin that allows the user to send a prompt to ChatGPT
 
 ## Requirements
 
+### Tools
 - **curl**: For API requests
 - **jq**: For JSON processing
-- **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from the [OpenAI Platform account](http://platform.openai.com/login)
+- **OpenAI API Key**: For sending ChatGPT prompts. Create an OpenAI platform account from [OpenAI account](http://platform.openai.com/login), or log in to an existing one. Generate an OpenAI API Key from the OpenAI dashboard -> View OpenAI Keys menu. 
+     
+ 
+## Examples
 
-## Requirements
+### Using environment variable set at upload time 
 
-- **curl**: For API requests
-- **jq**: For JSON processing
-- **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from your [OpenAI Platform account](http://platform.openai.com/login)
-
-## Quick Start
-1.  Create an OpenAI platform account from [OpenAI account](http://platform.openai.com/login), or log in to an existing one. Generate an OpenAI API Key from the OpenAI dashboard -> View OpenAI Keys menu. 
-2. Add to your Buildkite environment variable as `OPENAI_API_KEY` 
-3. For Buildkite secrets, create a repository pre-command hook (.buildkite/hooks/pre-command)  and set the environment variable: 
-   ```bash
-   #!/bin/bash
-   export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY) 
-   export BUILDKITE_API_TOKEN=$(buildkite-agent secret get BUILDKITE_API_TOKEN)    
-   ```   
-4. Add the plugin to your pipeline using the following examples
+Add the OpenAI API Key to your Buildkite environment variable as `OPENAI_API_KEY`
 
 ```
 steps:
-  # Option 1: Using environment variable set at upload time 
   - label: "🔍 Prompt ChatGPT to summarise test results"
     command: "npm test"
     plugins:
       - chatgpt-prompter#v0.0.1:
           api_key: "$$OPENAI_API_KEY" 
+```
 
-  # Option 2: Using Buildkite secrets (recommended)
-  # First, create .buildkite/hooks/pre-command with:
-  # export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY) 
-  # export BUILDKITE_API_TOKEN=$(buildkite-agent secret get BUILDKITE_API_TOKEN)   
+### Using Buildkite secrets (recommended)
+
+First, create .buildkite/hooks/pre-command and set the environment variables with the Buildkite secrets they are stored in. 
+
+```
+#!/bin/bash
+export OPENAI_API_KEY=$(buildkite-agent secret get OPENAI_API_KEY) 
+export BUILDKITE_API_TOKEN=$(buildkite-agent secret get BUILDKITE_API_TOKEN)    
+```
+
+Use the environment variables set in the plugin.
+
+```
+steps:
   - label: "🔍 Prompt ChatGPT to summarise build"
     command: echo "Summarise build"
     plugins:
@@ -47,9 +48,8 @@ steps:
 ```
 
 
-## Options
+## Configuration
 
-These are all the options available to configure this plugin's behaviour.
 
 ### Required
 
@@ -65,7 +65,7 @@ The name of the Buildkite secret key that contains your OpenAI API token to use 
 
 #### `buildkite_api_token` (string)
 
-The Buildkite API token to use for fetching build information from the Buildkite API to use for build analysis. If not specified, the plugin will look for BUILDKITE_API_TOKEN in the environment.
+The Buildkite API token to use for fetching build information from the Buildkite API to use for build analysis. If not specified, the plugin will look for `BUILDKITE_API_TOKEN` in the environment.
 
 
 #### `model` (string)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Buildkite plugin that allows the user to send a prompt to ChatGPT
 
+## Requirements
+
+- **curl**: For API requests
+- **jq**: For JSON processing
+- **OpenAI API Key**: For sending ChatGPT prompts. Keys can be created from the [OpenAI Platform account](http://platform.openai.com/login)
+
 ## Options
 
 These are all the options available to configure this plugin's behaviour.

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -55,7 +55,7 @@ fi
 
 ## Getting Build Information
 echo "Retrieving Build Information ..."
-get_build_information "${BUILDKITE_BUILD_ID}" "${BK_API_TOKEN}" || exit 1
+get_build_information "${BUILDKITE_BUILD_NUMBER}" "${BK_API_TOKEN}" || exit 1
 echo "✅ Build Information retrieved successfully."
 
 # Send the prompt to ChatGPT

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -9,18 +9,29 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 echo "--- :robot_face: ChatGPT Prompter Plugin"
 echo "Verifying plugin parameters..."
-API_SECRET_KEY=$(plugin_read_config API_SECRET_KEY_NAME "")
-if [ -z "${API_SECRET_KEY}" ]; then
-  echo '❌ Error: Missing Buildkite secret key. The OpenAI API Key is required for ChatGPT Log Analyser plugin'
+OPENAI_API_SECRET_KEY=$(plugin_read_config API_TOKEN_SECRET_KEY "")
+
+if [ -z "${OPENAI_API_SECRET_KEY}" ]; then
+  echo '❌ Error: Missing Buildkite secret key. The OpenAI API Key is required for ChatGPT Prompter plugin'
   exit 1
 fi
 
-API_SECRET_KEY_VALUE=$(buildkite-agent secret get "${API_SECRET_KEY}")  
-if [ -z "${API_SECRET_KEY_VALUE}" ]; then
-  echo "❌ Error: Failed to retrieve OpenAI API Key from Buildkite secret '$API_SECRET_KEY'."
+OPENAI_API_TOKEN=$(buildkite-agent secret get "${OPENAI_API_SECRET_KEY}")
+if [ -z "${OPENAI_API_TOKEN}" ]; then
+  echo "❌ Error: Failed to retrieve OpenAI API Key from Buildkite secret '$OPENAI_API_TOKEN'."
   return 1
 fi 
 echo "✅ OpenAI API Key retrieved successfully."
+
+BK_API_SECRET_KEY=$(plugin_read_config BK_API_SECRET_KEY "")
+if [ -z "${BK_API_SECRET_KEY}" ]; then
+  echo '❌ Error: Missing Buildkite secret key. The BK API Key is required for ChatGPT Prompter plugin'
+  exit 1
+fi
+
+BK_API_TOKEN=$(buildkite-agent secret get "${BK_API_SECRET_KEY}")
+validate_bk_token "${BK_API_TOKEN}" || exit 1 
+
 
 # Load Plugin configuration
 MODEL=$(plugin_read_config MODEL "gpt-4o-mini")

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -53,6 +53,11 @@ if [ -n "${SYSTEM_PROMPT}" ]; then
   echo "✅ System Prompt: ${SYSTEM_PROMPT}"
 fi
 
+## Getting Build Information
+echo "Retrieving Build Information ..."
+get_build_information "${BUILDKITE_BUILD_ID}" "${BK_API_TOKEN}" || exit 1
+echo "✅ Build Information retrieved successfully."
+
 # Send the prompt to ChatGPT
 # send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${USER_PROMPT}" "${SYSTEM_PROMPT}"
 echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -23,14 +23,14 @@ if [ -z "${OPENAI_API_TOKEN}" ]; then
 fi 
 echo "✅ OpenAI API Key retrieved successfully."
 
-BK_API_SECRET_KEY=$(plugin_read_config BK_API_SECRET_KEY "")
-if [ -z "${BK_API_SECRET_KEY}" ]; then
+BK_TOKEN_SECRET_KEY=$(plugin_read_config BK_TOKEN_SECRET_KEY "")
+if [ -z "${BK_TOKEN_SECRET_KEY}" ]; then
   echo '❌ Error: Missing Buildkite secret key. The BK API Key is required for ChatGPT Prompter plugin'
   exit 1
 fi
 
-BK_API_TOKEN=$(buildkite-agent secret get "${BK_API_SECRET_KEY}")
-validate_bk_token "${BK_API_TOKEN}" || exit 1 
+BK_API_TOKEN=$(buildkite-agent secret get "${BK_TOKEN_SECRET_KEY}")
+validate_bk_token "${BK_API_TOKEN}" || exit 1
 
 
 # Load Plugin configuration

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -15,15 +15,21 @@ validate_required_tools || exit 1
 # Get required plugin configurations
 echo "Retrieving OpenAI API Key ..."
 # Read plugin configuration for OpenAI API Key
-API_KEY=$(plugin_read_config API_KEY "")
-# Trim whitespaces from API_KEY
-API_KEY=$(echo "${API_KEY}" | xargs)
+API_KEY_CONFIG=$(plugin_read_config API_KEY "")
+# Evaluate the environment variable if it starts with $
+if [[ "${API_KEY_CONFIG}" =~ ^\$ ]]; then
+  API_KEY=$(eval "echo ${API_KEY_CONFIG}")
+else
+  API_KEY="${API_KEY_CONFIG}"
+fi
+# Trim any whitespace that might be causing issues
+API_KEY=$(echo "$API_KEY" | tr -d '[:space:]')
  
 if [ -z "${API_KEY}" ]; then
   echo '❌ Error: Missing OpenAI API Key. Please set the API_KEY in your plugin configuration.'
   exit 1
 fi  
-validate_api_key "${API_KEY}" || exit 1
+
 
 echo "Retrieving other plugin configurations ..."
 # Load Plugin configuration
@@ -31,10 +37,8 @@ MODEL=$(plugin_read_config MODEL "gpt-4o-mini")
 CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
 BUILDKITE_API_TOKEN=$(get_bk_api_token)
 
-echo "Using OpenAI API Key: ${API_KEY}"
 echo "Using Model: ${MODEL}"
-echo "Using Custom Prompt: ${CUSTOM_PROMPT:-Default prompt}"
-echo "Using Buildkite API Token: ${BUILDKITE_API_TOKEN:-Not set}"
+echo "Using Custom Prompt: ${CUSTOM_PROMPT:-}"
 
 validate_bk_token "${BUILDKITE_API_TOKEN}" || exit 1
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -61,5 +61,6 @@ fi
 echo "✅ Build Information retrieved successfully."
 
 # Send the prompt to ChatGPT
+echo "Sending build information to ChatGPT for analysis  ..."
 send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${CUSTOM_PROMPT}" "${BUILD_INFO}"  
 echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -42,22 +42,24 @@ if [ -z "${MODEL}" ]; then
   exit 1
 fi
 
-USER_PROMPT=$(plugin_read_config USER_PROMPT "ping")
-SYSTEM_PROMPT=$(plugin_read_config SYSTEM_PROMPT "")
+CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "") 
 
 # Set the model environment variable
 
-echo "✅ Model: ${MODEL}"
-echo "✅ User Prompt: ${USER_PROMPT}"
-if [ -n "${SYSTEM_PROMPT}" ]; then
-  echo "✅ System Prompt: ${SYSTEM_PROMPT}"
+echo "✅ Model: ${MODEL}" 
+if [ -n "${CUSTOM_PROMPT}" ]; then
+  echo "✅ Custom Prompt: ${CUSTOM_PROMPT}"
 fi
 
 ## Getting Build Information
 echo "Retrieving Build Information ..."
-get_build_information "${BUILDKITE_BUILD_NUMBER}" "${BK_API_TOKEN}" || exit 1
+BUILD_INFO=$(get_current_build_information "${BK_API_TOKEN}")
+if [ -z "${BUILD_INFO}" ]; then
+  echo "❌ Error: Failed to retrieve build information from Buildkite API. Please check the Buildkite API token and organization/pipeline configuration."
+  exit 1
+fi
 echo "✅ Build Information retrieved successfully."
 
 # Send the prompt to ChatGPT
-# send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${USER_PROMPT}" "${SYSTEM_PROMPT}"
+send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${CUSTOM_PROMPT}" "${BUILD_INFO}"  
 echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,7 +8,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/plugin.bash"
 
 echo "--- :robot_face: ChatGPT Prompter Plugin"
-echo "Verifying plugin parameters..."
+echo "Retrieving OpenAI API Key ..."
 OPENAI_API_SECRET_KEY=$(plugin_read_config API_TOKEN_SECRET_KEY "")
 
 if [ -z "${OPENAI_API_SECRET_KEY}" ]; then
@@ -23,6 +23,7 @@ if [ -z "${OPENAI_API_TOKEN}" ]; then
 fi 
 echo "✅ OpenAI API Key retrieved successfully."
 
+echo "Retrieving Buildkite API Token ..."
 BK_TOKEN_SECRET_KEY=$(plugin_read_config BK_TOKEN_SECRET_KEY "")
 if [ -z "${BK_TOKEN_SECRET_KEY}" ]; then
   echo '❌ Error: Missing Buildkite secret key. The BK API Key is required for ChatGPT Prompter plugin'
@@ -32,6 +33,7 @@ fi
 BK_API_TOKEN=$(buildkite-agent secret get "${BK_TOKEN_SECRET_KEY}")
 validate_bk_token "${BK_API_TOKEN}" || exit 1
 
+echo "Retrieving other plugin configurations ..."
 
 # Load Plugin configuration
 MODEL=$(plugin_read_config MODEL "gpt-4o-mini")

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -52,5 +52,5 @@ if [ -n "${SYSTEM_PROMPT}" ]; then
 fi
 
 # Send the prompt to ChatGPT
-send_prompt "${API_SECRET_KEY_VALUE}" "${MODEL}" "${USER_PROMPT}" "${SYSTEM_PROMPT}"
+# send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${USER_PROMPT}" "${SYSTEM_PROMPT}"
 echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,59 +8,32 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/plugin.bash"
 
 echo "--- :robot_face: ChatGPT Prompter Plugin"
+
+# Validate required tools
+validate_required_tools || exit 1
+
+# Get required plugin configurations
 echo "Retrieving OpenAI API Key ..."
-OPENAI_API_SECRET_KEY=$(plugin_read_config API_TOKEN_SECRET_KEY "")
-
-if [ -z "${OPENAI_API_SECRET_KEY}" ]; then
-  echo '❌ Error: Missing Buildkite secret key. The OpenAI API Key is required for ChatGPT Prompter plugin'
+# Read plugin configuration for OpenAI API Key
+API_KEY=$(plugin_read_config API_KEY "")
+# Trim whitespaces from API_KEY
+API_KEY=$(echo "${API_KEY}" | xargs)
+ 
+if [ -z "${API_KEY}" ]; then
+  echo '❌ Error: Missing OpenAI API Key. Please set the API_KEY in your plugin configuration.'
   exit 1
-fi
-
-OPENAI_API_TOKEN=$(buildkite-agent secret get "${OPENAI_API_SECRET_KEY}")
-if [ -z "${OPENAI_API_TOKEN}" ]; then
-  echo "❌ Error: Failed to retrieve OpenAI API Key from Buildkite secret '$OPENAI_API_TOKEN'."
-  return 1
-fi 
-echo "✅ OpenAI API Key retrieved successfully."
-
-echo "Retrieving Buildkite API Token ..."
-BK_TOKEN_SECRET_KEY=$(plugin_read_config BK_TOKEN_SECRET_KEY "")
-if [ -z "${BK_TOKEN_SECRET_KEY}" ]; then
-  echo '❌ Error: Missing Buildkite secret key. The BK API Key is required for ChatGPT Prompter plugin'
-  exit 1
-fi
-
-BK_API_TOKEN=$(buildkite-agent secret get "${BK_TOKEN_SECRET_KEY}")
-validate_bk_token "${BK_API_TOKEN}" || exit 1
+fi  
+validate_api_key "${API_KEY}" || exit 1
 
 echo "Retrieving other plugin configurations ..."
-
 # Load Plugin configuration
 MODEL=$(plugin_read_config MODEL "gpt-4o-mini")
-if [ -z "${MODEL}" ]; then
-  echo "❌ Error: Missing or invalid model configuration. Please set the MODEL in your plugin configuration."
-  exit 1
-fi
+CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
+BUILDKITE_API_TOKEN=$(get_bk_api_token)
 
-CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "") 
-
-# Set the model environment variable
-
-echo "✅ Model: ${MODEL}" 
-if [ -n "${CUSTOM_PROMPT}" ]; then
-  echo "✅ Custom Prompt: ${CUSTOM_PROMPT}"
-fi
-
-## Getting Build Information
-echo "Retrieving Build Information ..."
-BUILD_INFO=$(get_current_build_information "${BK_API_TOKEN}")
-if [ -z "${BUILD_INFO}" ]; then
-  echo "❌ Error: Failed to retrieve build information from Buildkite API. Please check the Buildkite API token and organization/pipeline configuration."
-  exit 1
-fi
-echo "✅ Build Information retrieved successfully."
+validate_bk_token "${BUILDKITE_API_TOKEN}" || exit 1
 
 # Send the prompt to ChatGPT
 echo "Sending build information to ChatGPT for analysis  ..."
-send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${CUSTOM_PROMPT}" "${BUILD_INFO}"  
+send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${CUSTOM_PROMPT}" "${BUILDKITE_API_TOKEN}"  
 echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -44,5 +44,5 @@ validate_bk_token "${BUILDKITE_API_TOKEN}" || exit 1
 
 # Send the prompt to ChatGPT
 echo "Sending build information to ChatGPT for analysis  ..."
-send_prompt "${OPENAI_API_TOKEN}" "${MODEL}" "${CUSTOM_PROMPT}" "${BUILDKITE_API_TOKEN}"  
+send_prompt "${API_KEY}" "${MODEL}" "${CUSTOM_PROMPT}" "${BUILDKITE_API_TOKEN}"  
 echo "~~~ Done."

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -31,6 +31,11 @@ MODEL=$(plugin_read_config MODEL "gpt-4o-mini")
 CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
 BUILDKITE_API_TOKEN=$(get_bk_api_token)
 
+echo "Using OpenAI API Key: ${API_KEY}"
+echo "Using Model: ${MODEL}"
+echo "Using Custom Prompt: ${CUSTOM_PROMPT:-Default prompt}"
+echo "Using Buildkite API Token: ${BUILDKITE_API_TOKEN:-Not set}"
+
 validate_bk_token "${BUILDKITE_API_TOKEN}" || exit 1
 
 # Send the prompt to ChatGPT

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -61,26 +61,14 @@ function plugin_read_config() {
   echo "${!var:-$default}"
 }
 
-function get_bk_token() {
-  local bk_api_secret_key=$(plugin_read_config "BK_API_SECRET_KEY" "")
-  if [ -z "${bk_api_secret_key}" ]; then
-    echo "" 
-  bk_api_token=$(buildkite-agent secret get "${BK_API_SECRET_KEY}")
-  if [ -z "${bk_api_token}" ]; then
-    echo "❌ Error: Failed to retrieve BK API Key from Buildkite secret '$BK_API_SECRET_KEY'."
-    return 1
-  fi
-
-  echo "${bk_api_token}"
-}
-
 function validate_bk_token() {
   local bk_api_token="$1"
+  local errors=0
 
   # Check if the BK API token is valid
   if [ -z "${bk_api_token}" ]; then
     echo "❌ Error: Missing Buildkite API token."
-    return 1
+    errors=$((errors + 1))
   fi
 
   #validate token scope
@@ -91,14 +79,14 @@ function validate_bk_token() {
   echo "--- Buildkite API Token Scopes ---"
   echo "${response}" | jq -r '.scopes[]'
 
-  
+
   scopes=$(echo "${response}" | jq -r '.scopes[]')
   if [[ "${scopes}" =~ write ]]; then
     echo "❌ Error: The Buildkite API token has write permissions which are not allowed for security reasons."
-    return 1
+    errors=$((errors + 1))
   fi
   echo "✅ Buildkite API token is valid and has appropriate read-only scopes."
-  return 0
+  return ${error}
 }
 
 function send_prompt() {

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -73,9 +73,7 @@ function validate_bk_token() {
   #validate token scope
   response=$(curl -H "Authorization: Bearer ${bk_api_token}" \
     -X GET "https://api.buildkite.com/v2/access-token")
- 
-
-  echo "--- Buildkite API Token Scopes ---"
+  
   #check if response is 200
   if [ $? -ne 0 ]; then
     echo "❌ Error: Invalid Buildkite API token. Please check the token configured in your cluster secrets."
@@ -92,9 +90,9 @@ function validate_bk_token() {
     return 1
   fi 
 
-  scopes=$(echo "${response}" | jq -r '.scopes[]')  
-  echo "Scopes: ${scopes}"
+  scopes=$(echo "${response}" | jq -r '.scopes[]')   
   if [[ "${scopes}" =~ write ]]; then
+    echo "Scopes: ${scopes}"  
     echo "❌ Error: The Buildkite API token has write permissions which are not allowed to use in this plugin for security reasons."
     return 1
   fi

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -100,12 +100,12 @@ function validate_bk_token() {
   return 0
 }
 
-function get_build_information() {
-  local build_id="$1"
+function get_build_information() { 
+  local build_number="$1"
   local bk_api_token="$2"
 
   # Fetch build information from Buildkite API
-  response=$(curl -sS -X GET "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}" \
+  response=$(curl -sS -X GET "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${build_number}" \
     -H "Authorization: Bearer ${bk_api_token}" \
     -H "Content-Type: application/json")
   if [ $? -ne 0 ]; then

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -103,6 +103,9 @@ function validate_bk_token() {
 function get_build_information() { 
   local build_number="$1"
   local bk_api_token="$2"
+ 
+  build_url="https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${build_number}"
+  echo "Retrieving Build Information for build number: ${build_url} ..."
 
   # Fetch build information from Buildkite API
   response=$(curl -sS -X GET "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${build_number}" \
@@ -117,7 +120,7 @@ function get_build_information() {
     return 1
   fi
 
-  echo "${response}" | jq -r '. | {build_id: .id, build_number: .number, pipeline_slug: .pipeline.slug, organization_slug: .organization.slug}'
+  echo "${response}" ###  | jq -r '. | {build_id: .id, build_number: .number, pipeline_slug: .pipeline.slug, organization_slug: .organization.slug}'
 }
 
 function send_prompt() {

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -99,7 +99,7 @@ function validate_api_key() {
   fi
 
   # Optionally, you can add more validation logic here (e.g., checking format)
-  echo "✅ OpenAI API key is valid."
+  echo "✅ OpenAI API key found."
   return 0
 }
 

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -62,13 +62,12 @@ function plugin_read_config() {
 }
 
 function validate_bk_token() {
-  local bk_api_token="$1"
-  local errors=0
+  local bk_api_token="$1" 
 
   # Check if the BK API token is valid
   if [ -z "${bk_api_token}" ]; then
     echo "❌ Error: Missing Buildkite API token."
-    errors=$((errors + 1))
+    return 1
   fi
 
   #validate token scope
@@ -83,10 +82,10 @@ function validate_bk_token() {
   scopes=$(echo "${response}" | jq -r '.scopes[]')
   if [[ "${scopes}" =~ write ]]; then
     echo "❌ Error: The Buildkite API token has write permissions which are not allowed for security reasons."
-    errors=$((errors + 1))
+    return 1
   fi
   echo "✅ Buildkite API token is valid and has appropriate read-only scopes."
-  return ${error}
+  return 0
 }
 
 function send_prompt() {

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -243,11 +243,11 @@ function format_payload() {
   payload=$(jq -n \
     --arg model "$model" \
     --arg system_prompt "$base_prompt" \
-    --arg user_prompt "$base_prompt" \         
-    '{
+    --arg build_info "$build_info" \
+     '{
       model: $model,
       messages: [
-        { role: "system", content: $base_prompt },
+        { role: "system", content: $system_prompt },
         { role: "user", content: $build_info }
       ]
     }') 

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -76,10 +76,24 @@ function validate_bk_token() {
  
 
   echo "--- Buildkite API Token Scopes ---"
-  echo "${response}" | jq -r '.scopes[]'
+  #check if response is 200
+  if [ $? -ne 0 ]; then
+    echo "❌ Error: Failed to retrieve Buildkite API token scopes. Please check your Buildkite API token."
+    return 1
+  fi
+  #check if response is empty
+  if [ -z "${response}" ]; then
+    echo "❌ Error: Failed to retrieve Buildkite API token scopes."
+    return 1
+  fi
 
+  if ! echo "${response}" | jq -e '.scopes' > /dev/null; then
+    echo "❌ Error: No scopes found in the Buildkite API token response."
+    return 1
+  fi 
 
-  scopes=$(echo "${response}" | jq -r '.scopes[]')
+  scopes=$(echo "${response}" | jq -r '.scopes[]')  
+  echo "Scopes: ${scopes}"
   if [[ "${scopes}" =~ write ]]; then
     echo "❌ Error: The Buildkite API token has write permissions which are not allowed for security reasons."
     return 1

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -78,11 +78,25 @@ function validate_required_tools() {
   return ${errors}
 }
 
+function get_openai_api_key() {
+  local api_key_config=""
+
+  api_key_config=$(plugin_read_config API_KEY "")
+  if [[ "${api_key_config}" =~ ^\$ ]]; then
+    api_key_config="$(eval "echo ${api_key_config}")"
+  else
+    api_key_config="${api_key_config}"
+  fi
+  # Trim any whitespace that might be causing issues
+  api_key_config=$(echo "$api_key_config" | tr -d '[:space:]')
+  echo "${api_key_config}"
+}
+
 function get_bk_api_token() {
   local bk_token_config=""
 
   bk_token_config=$(plugin_read_config BUILDKITE_API_TOKEN "")
-if [[ "${bk_token_config}" =~ ^\$ ]]; then
+  if [[ "${bk_token_config}" =~ ^\$ ]]; then
     echo "$(eval "echo ${bk_token_config}")"
     
   else

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -100,6 +100,26 @@ function validate_bk_token() {
   return 0
 }
 
+function get_build_information() {
+  local build_id="$1"
+  local bk_api_token="$2"
+
+  # Fetch build information from Buildkite API
+  response=$(curl -sS -X GET "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}" \
+    -H "Authorization: Bearer ${bk_api_token}" \
+    -H "Content-Type: application/json")
+  if [ $? -ne 0 ]; then
+    echo "❌ Error: Failed to retrieve build information from Buildkite API."
+    return 1
+  fi
+  if [ -z "${response}" ]; then
+    echo "❌ Error: No information retrieved from the current build."
+    return 1
+  fi
+
+  echo "${response}" | jq -r '. | {build_id: .id, build_number: .number, pipeline_slug: .pipeline.slug, organization_slug: .organization.slug}'
+}
+
 function send_prompt() {
   local api_secret_key="$1"
   local model="$2"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -61,6 +61,46 @@ function plugin_read_config() {
   echo "${!var:-$default}"
 }
 
+function get_bk_token() {
+  local bk_api_secret_key=$(plugin_read_config "BK_API_SECRET_KEY" "")
+  if [ -z "${bk_api_secret_key}" ]; then
+    echo "" 
+  bk_api_token=$(buildkite-agent secret get "${BK_API_SECRET_KEY}")
+  if [ -z "${bk_api_token}" ]; then
+    echo "❌ Error: Failed to retrieve BK API Key from Buildkite secret '$BK_API_SECRET_KEY'."
+    return 1
+  fi
+
+  echo "${bk_api_token}"
+}
+
+function validate_bk_token() {
+  local bk_api_token="$1"
+
+  # Check if the BK API token is valid
+  if [ -z "${bk_api_token}" ]; then
+    echo "❌ Error: Missing Buildkite API token."
+    return 1
+  fi
+
+  #validate token scope
+  response=$(curl -H "Authorization: Bearer ${bk_api_token}" \
+    -X GET "https://api.buildkite.com/v2/access-token")
+ 
+
+  echo "--- Buildkite API Token Scopes ---"
+  echo "${response}" | jq -r '.scopes[]'
+
+  
+  scopes=$(echo "${response}" | jq -r '.scopes[]')
+  if [[ "${scopes}" =~ write ]]; then
+    echo "❌ Error: The Buildkite API token has write permissions which are not allowed for security reasons."
+    return 1
+  fi
+  echo "✅ Buildkite API token is valid and has appropriate read-only scopes."
+  return 0
+}
+
 function send_prompt() {
   local api_secret_key="$1"
   local model="$2"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -78,24 +78,24 @@ function validate_bk_token() {
   echo "--- Buildkite API Token Scopes ---"
   #check if response is 200
   if [ $? -ne 0 ]; then
-    echo "❌ Error: Failed to retrieve Buildkite API token scopes. Please check your Buildkite API token."
+    echo "❌ Error: Invalid Buildkite API token. Please check the token configured in your cluster secrets."
     return 1
   fi
   #check if response is empty
   if [ -z "${response}" ]; then
-    echo "❌ Error: Failed to retrieve Buildkite API token scopes."
+    echo "❌ Error: Failed to validate the Buildkite API token provided."
     return 1
   fi
 
   if ! echo "${response}" | jq -e '.scopes' > /dev/null; then
-    echo "❌ Error: No scopes found in the Buildkite API token response."
+    echo "❌ Error: Failed to validate the scope of the Buildkite API token provided."
     return 1
   fi 
 
   scopes=$(echo "${response}" | jq -r '.scopes[]')  
   echo "Scopes: ${scopes}"
   if [[ "${scopes}" =~ write ]]; then
-    echo "❌ Error: The Buildkite API token has write permissions which are not allowed for security reasons."
+    echo "❌ Error: The Buildkite API token has write permissions which are not allowed to use in this plugin for security reasons."
     return 1
   fi
   echo "✅ Buildkite API token is valid and has appropriate read-only scopes."

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,10 +6,10 @@ requirements:
   - curl
 configuration:
   properties:
-    api_token_secret_key:
+    api_key:
       type: string
       description: The Buildkite Secret key name that stores the OpenAI API Key to use for ChatGPT access.  
-    bk_token_secret_key:
+    buildkite_api_token:
       type: string
       description: The Buildkite Secret key name that stores a Buildkite API Token with read-only scope.  
     model:
@@ -21,5 +21,4 @@ configuration:
       type: string
       description: Additional context to prompt ChatGPT for include in its analysis. 
   required:
-    - api_token_secret_key
-    - bk_token_secret_key
+    - api_key 

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,9 +6,12 @@ requirements:
   - curl
 configuration:
   properties:
-    api_secret_key_name:
+    api_token_secret_key:
       type: string
       description: The Buildkite Secret key name that stores the OpenAI API Key to use for ChatGPT access.  
+    bk_token_secret_key:
+      type: string
+      description: The Buildkite Secret key name that stores a Buildkite API Token with read-only scope.  
     model:
       type: string
       description: ChatGPT model to use.

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,13 +16,10 @@ configuration:
       type: string
       description: ChatGPT model to use.
       enum: [gpt-4o-mini, gpt-4, gpt-3.5-turbo]
-      default: gpt-4o-mini
-    system_prompt:
+      default: gpt-4o-mini 
+    custom_prompt:
       type: string
-      description: The system prompt to send to ChatGPT
-    user_prompt:
-      type: string
-      description: The user prompt to send to ChatGPT. Defaults to "ping" the ChatGPT API.
-      default: ping
+      description: Additional context to prompt ChatGPT for include in its analysis. 
   required:
-    - api_secret_key
+    - api_token_secret_key
+    - bk_token_secret_key


### PR DESCRIPTION
This PR implements the following linear tickets to provide Build Analysis to the current build using ChatGPT:

- [SUP-4424: Provide a Buildkite API token to the plugin via parameters](https://linear.app/buildkite/issue/SUP-4424/provide-a-buildkite-api-token-to-the-plugin-via-parameters)
- [SUP-4425: Implement a `get_build` in the OpenAI plugin](https://linear.app/buildkite/issue/SUP-4425/implement-a-get-build-in-the-openai-plugin)
- [SUP-4426: Annotate the current build with optimisations from the build analysis](https://linear.app/buildkite/issue/SUP-4426/annotate-the-current-build-with-optimisations-from-the-build-analysis)
